### PR TITLE
Multiple supplements

### DIFF
--- a/example/example-compact.typ
+++ b/example/example-compact.typ
@@ -1,6 +1,7 @@
 #set page(width: 15cm, height: auto)
 
-#import "@preview/smartaref:0.1.0"
+// #import "@preview/smartaref:0.1.0"
+#import "../src/lib.typ" as smartaref
 
 #let cref = smartaref.cref.with(compact: true)
 #let Cref = smartaref.Cref.with(compact: true)
@@ -190,3 +191,15 @@ $ (cos x + i sin x)^n = cos(n x) + i sin(n x) $ <eq-de-moivres-formula>
 `cref`: See #cref(supplement: "footnotes")[@foot-foo @foot-bar @foot-baz @foot-qux].
 
 A few#footnote[foo]<foot-foo> footnotes#footnote[bar]<foot-bar> are present#footnote[baz]<foot-baz> in this sentence.#footnote[qux]<foot-qux>
+
+// === [ mixed example ] ===================================================
+
+= Mixed example
+
+`ref`: See @fig-foo, @tbl-foo, @tbl-bar, @eq-pythagoras, @eq-eulers-identity and @eq-de-moivres-formula
+
+#emph[`compact: false`] \
+`cref`: See #cref(compact: false)[@fig-foo @fig-bar @fig-baz @tbl-foo @tbl-bar @tbl-baz @eq-pythagoras @eq-eulers-identity @eq-de-moivres-formula].
+
+#emph[`compact: true`] \
+`cref`: See #cref[@fig-foo @fig-bar @fig-baz @tbl-foo @tbl-bar @tbl-baz @eq-pythagoras @eq-eulers-identity  @eq-de-moivres-formula].

--- a/example/example.typ
+++ b/example/example.typ
@@ -1,6 +1,7 @@
 #set page(width: 12cm, height: auto)
 
-#import "@preview/smartaref:0.1.0": cref, Cref
+// #import "@preview/smartaref:0.1.0": cref, Cref
+#import "../src/lib.typ": cref, Cref
 
 // Highlight links.
 #show link: set text(fill: blue)
@@ -155,3 +156,13 @@ $ (cos x + i sin x)^n = cos(n x) + i sin(n x) $ <eq-de-moivres-formula>
 `Cref`: #Cref(supplement: "Footnotes")[@foot-foo @foot-bar @foot-baz @foot-qux] are ...
 
 A few#footnote[foo]<foot-foo> footnotes#footnote[bar]<foot-bar> are present#footnote[baz]<foot-baz> in this sentence.#footnote[qux]<foot-qux>
+
+// === [ mixed example ] ===================================================
+
+= Mixed example
+
+`ref`: See @fig-foo, @tbl-foo, @tbl-bar, @eq-pythagoras, @eq-eulers-identity and @eq-de-moivres-formula
+
+`cref`: See #cref[@fig-foo @tbl-foo @tbl-bar @eq-pythagoras @eq-eulers-identity @eq-de-moivres-formula].
+
+`Cref`: #Cref[@fig-foo @tbl-foo @tbl-bar @eq-pythagoras @eq-eulers-identity  @eq-de-moivres-formula] are above

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -53,6 +53,26 @@
 	capital: false,
 ) = {
 	let target = query(refs.first().target).first()
+	let s = get-supplement(refs)
+	if s == none { return none }
+	if refs.len() > 1 {
+		let singular = s.trim(regex("[.]")) // remove trailing dot if present (e.g. "Fig.")
+		let plural = pluralize(singular)
+		s = s.replace(singular, plural)
+	}
+	if capital {
+		title-case(s)
+	} else {
+		lower(s)
+	}
+}
+
+// get-supplement determines the (simple) supplement for a given
+#let get-supplement(
+	// A reference for which to provide a supplement.
+	ref,
+) = {
+	let target = query(ref.target).first()
 	let supplement = none
 	if target.has("supplement") {
 		if target.supplement.has("text") {
@@ -69,17 +89,37 @@
 		//return [ fields: #target.fields() \ ]
 		panic("unable to get supplement of target '" + str(type(target)) + "'")
 	}
-	let s = supplement
-	if refs.len() > 1 {
-		let singular = s.trim(regex("[.]")) // remove trailing dot if present (e.g. "Fig.")
-		let plural = pluralize(singular)
-		s = s.replace(singular, plural)
+	return supplement
+}
+
+// batch-supplements returns the initial sequence of references with the same
+// supplement.
+#let batch-supplements(
+	// An array of references for which to provide a supplement.
+	refs,
+) = {
+	refs = refs.pos()
+	let output = ()
+	let supplement = none
+	let batch = ()
+	// if supplement == none { return (batch,refs) }
+	while refs.len() > 0 { 
+		let (ref,..refs) = refs
+		supplement = get-supplement(ref)
+		batch.push(ref)
+		let s = none
+		while refs.len() > 0 {
+			ref = refs.first()
+			s = get-supplement(ref)
+			if s == none or supplement != s {
+				break
+			}
+			batch.pop(ref)
+			refs = refs.slice(1)
+		}
+		output.push((supplement,batch))
 	}
-	if capital {
-		title-case(s)
-	} else {
-		lower(s)
-	}
+	return output
 }
 
 // is-consecutive reports whether the given numberings follow one another in

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -106,7 +106,7 @@
     batches.push((s, batch))
   }
   // (Optionally) Capitalise and pluralize supplements
-  return batches.map(((s, batch)) => {
+  return batches.enumerate().map((i,(s, batch)) => {
     if s == none {
       return (s, batch)
     }
@@ -115,7 +115,7 @@
       let plural = pluralize(singular)
       s = s.replace(singular, plural)
     }
-    if capital {
+    if capital and i == 0 {
       s = title-case(s)
     } else {
       s = lower(s)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -44,83 +44,86 @@
 	s.slice(c.len(),)
 }
 
-// supplement-func returns an (optionally capitalized) supplement for the given
-// list of references.
-#let supplement-func(
-	// An array of references for which to provide a supplement.
-	refs,
-	// Whether to capitalize the supplement.
-	capital: false,
+// simple-supplement returns the (simple) supplement for a given
+// ref
+#let simple-supplement(
+  // A reference for which to provide a supplement.
+  ref,
 ) = {
-	let target = query(refs.first().target).first()
-	let s = get-supplement(refs)
-	if s == none { return none }
-	if refs.len() > 1 {
-		let singular = s.trim(regex("[.]")) // remove trailing dot if present (e.g. "Fig.")
-		let plural = pluralize(singular)
-		s = s.replace(singular, plural)
-	}
-	if capital {
-		title-case(s)
-	} else {
-		lower(s)
-	}
-}
-
-// get-supplement determines the (simple) supplement for a given
-#let get-supplement(
-	// A reference for which to provide a supplement.
-	ref,
-) = {
-	let target = query(ref.target).first()
-	let supplement = none
-	if target.has("supplement") {
-		if target.supplement.has("text") {
-			supplement = target.supplement.text
-		} else if type(target.supplement) == content {
-			return target.supplement
-		} else {
-			//return [ fields: #target.supplement.fields() \ ]
-			panic("unable to get supplement (with type '" + str(type(target.supplement)) + "') of target '" + str(type(target)) + "'")
-		}
-	} else if is-footnote(target) {
-		return none // no default supplement for footnotes
-	} else {
-		//return [ fields: #target.fields() \ ]
-		panic("unable to get supplement of target '" + str(type(target)) + "'")
-	}
+  let target = query(ref.target).first()
+  let supplement = none
+  if target.has("supplement") {
+    if target.supplement.has("text") {
+      supplement = target.supplement.text
+    } else if type(target.supplement) == content {
+      return target.supplement
+    } else {
+      //return [ fields: #target.supplement.fields() \ ]
+      panic(
+        "unable to get supplement (with type '"
+          + str(type(target.supplement))
+          + "') of target '"
+          + str(type(target))
+          + "'",
+      )
+    }
+  } else if is-footnote(target) {
+    return none // no default supplement for footnotes
+  } else {
+    //return [ fields: #target.fields() \ ]
+    panic("unable to get supplement of target '" + str(type(target)) + "'")
+  }
 	return supplement
 }
 
-// batch-supplements returns the initial sequence of references with the same
-// supplement.
-#let batch-supplements(
-	// An array of references for which to provide a supplement.
-	refs,
+// supplement-func returns an array of pairs consisting of an 
+// (optionally capitalized) supplement and an associated array
+// of references.
+#let supplement-func(
+  // An array of references for which to provide a supplement.
+  refs,
+  // Determined by a function which returns a supplement to a ref
+  supplement: simple-supplement,
+  // Whether to capitalize the supplement.
+  capital: false,
 ) = {
-	refs = refs.pos()
-	let output = ()
-	let supplement = none
-	let batch = ()
-	// if supplement == none { return (batch,refs) }
-	while refs.len() > 0 { 
-		let (ref,..refs) = refs
-		supplement = get-supplement(ref)
-		batch.push(ref)
-		let s = none
-		while refs.len() > 0 {
-			ref = refs.first()
-			s = get-supplement(ref)
-			if s == none or supplement != s {
-				break
-			}
-			batch.pop(ref)
-			refs = refs.slice(1)
-		}
-		output.push((supplement,batch))
-	}
-	return output
+  let batches = ()
+  let ref = none
+  while refs.len() > 0 {
+    (ref, ..refs) = refs
+    let batch = (ref,)
+    let s = supplement(ref)
+    // Do not combine refs with 'none' supplements  
+    if s == none { break }
+    while refs.len() > 0 {
+      let ref = refs.first()
+      // Stop if next ref has different supplement
+      if supplement(ref) != s { break }
+      // o/w collect ref and remove from list
+      batch.push(ref)
+      (_, ..refs) = refs
+    }
+    batches.push((s, batch))
+  }
+  // (Optionally) Capitalise and pluralize supplements
+  return batches.map(((s, batch)) => {
+    if s == none {
+      return (s, batch)
+    }
+    if batch.len() > 1 {
+      let singular = s.trim(regex("[.]")) // remove trailing dot if present (e.g. "Fig.")
+      let plural = pluralize(singular)
+      s = s.replace(singular, plural)
+    }
+    if capital {
+      s = title-case(s)
+    } else {
+      s = lower(s)
+    }
+    return (s, batch)
+  })
 }
+
 
 // is-consecutive reports whether the given numberings follow one another in
 // consecutive order (e.g. `(3, 1, 2)` is followed by `(3, 1, 3)`).
@@ -193,7 +196,7 @@
 	// An alternative separator between the last two references.
 	last: " and ",
 ) = {
-	args.join(separator, last: last)
+  args.join(separator, last: last)
 }
 
 #let cref(
@@ -211,74 +214,79 @@
 	// - A `string` (e.g. "figures" or "tables").
 	// - A `content` value.
 	// - A `function` taking a list of references and a boolean to optionally
-	//   capitalize the returned supplement.
+	//   capitalize the returned supplement and returning a sequence of 
+	// 	 supplement and list-or-references pairs
 	supplement: supplement-func,
 	// A function used to join references.
 	join-func: join-func,
 ) = context {
-	let refs = ()
-	for arg in args.pos() {
-		let children = ()
-		if arg.has("children") {
-			children = arg.children
-		} else {
-			children.push(arg)
-		}
-		for child in children {
-			if is-ref(child) {
-				refs.push(child)
-			}
-		}
-	}
-	if supplement != none {
-		if type(supplement) == str or type(supplement) == content {
-			supplement
-		} else if type(supplement) == function {
-			supplement(refs)
-		} else {
-			panic("support for supplement '" + str(type(supplement)) + "' not yet supported")
-		}
-		[ ]
-	}
-	let targets = ()
-	for ref in refs {
-		let target = query(ref.target).first()
-		targets.push(target)
-	}
-	let short-refs = () // short references (e.g. "1" instead of "Figure 1")
-	let all-nums = ()   // array of counter numberings.
-	for target in targets {
-		let elem = target
-		let c = none
-		if elem.has("counter") {
-			c = elem.counter
-		} else if is-heading(elem) {
-			c = counter(heading)
-		} else if is-equation(elem) {
-			c = counter(math.equation)
-		} else if is-footnote(elem) {
-			c = counter(footnote)
-		} else {
-			//return [ fields: #elem.fields() \ ]
-			panic("unable to get counter of element '" + str(type(elem)) + "'")
-		}
-		let nums = c.at(elem.location())
-		let text = std.numbering(elem.numbering, ..nums)
-		let short-ref = link(
-			target.label,
-			text,
-		)
-		short-refs.push(short-ref)
-		all-nums.push(nums)
-	}
-	if compact {
-		// compact consecutive references (e.g. "figs. 1, 2, 3 and 4" becomes
-		// "figs. 1 to 4").
-		let compacted-refs = compact-func(short-refs, all-nums)
-		join-func(compacted-refs)
-	} else {
-		join-func(short-refs)
-	}
+  let refs = ()
+  for arg in args.pos() {
+    let children = ()
+    if arg.has("children") {
+      children = arg.children
+    } else {
+      children.push(arg)
+    }
+    for child in children {
+      if is-ref(child) {
+        refs.push(child)
+      }
+    }
+  }
+  let batches = ()
+  if supplement != none {
+    if type(supplement) == str or type(supplement) == content {
+      batches = ((supplement , refs),)
+    } else if type(supplement) == function {
+      batches = supplement(refs)
+    } else {
+      panic("support for supplement '" + str(type(supplement)) + "' not yet supported")
+    }
+  }
+  let output = ()
+  for (s,refs) in batches {
+    let targets = ()
+    for ref in refs {
+      let target = query(ref.target).first()
+      targets.push(target)
+    }
+    let short-refs = () // short references (e.g. "1" instead of "Figure 1")
+    let all-nums = () // array of counter numberings.
+    for target in targets {
+      let elem = target
+      let c = none
+      if elem.has("counter") {
+        c = elem.counter
+      } else if is-heading(elem) {
+        c = counter(heading)
+      } else if is-equation(elem) {
+        c = counter(math.equation)
+      } else if is-footnote(elem) {
+        c = counter(footnote)
+      } else {
+        //return [ fields: #elem.fields() \ ]
+        panic("unable to get counter of element '" + str(type(elem)) + "'")
+      }
+      let nums = c.at(elem.location())
+      let text = std.numbering(elem.numbering, ..nums)
+      let short-ref = link(
+        target.label,
+        text,
+      )
+      short-refs.push(short-ref)
+      all-nums.push(nums)
+    }
+    if compact {
+      // compact consecutive references (e.g. "figs. 1, 2, 3 and 4" becomes
+      // "figs. 1 to 4").
+      let compacted-refs = compact-func(short-refs, all-nums)
+      output.push(s + [~] + join-func(compacted-refs))
+    } else {
+      output.push(s + [~] + join-func(short-refs))
+    }
+  }
+  return join-func(output)
 }
 
 #let Cref = cref.with(

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -106,7 +106,7 @@
     batches.push((s, batch))
   }
   // (Optionally) Capitalise and pluralize supplements
-  return batches.enumerate().map((i,(s, batch)) => {
+  return batches.enumerate().map( ((i, (s, batch))) => {
     if s == none {
       return (s, batch)
     }


### PR DESCRIPTION
closes #2 

This PR handles references with different supplements. The initial list of references (handed to `#cref` or `#Cref` ) is  ‘chunked’ into portions with a common supplement (except if the supplement is `none` ). The chunks are each handled as per the previous implementation. Example files `example.typ` and `example-compact.typ` have been expanded to show new functionality. 

NB. The two example files are now importing `lib.typ` to access the new functions. Their preambles need to be adjusted.